### PR TITLE
LIBASPACE-89 remove call to browser_support partial

### DIFF
--- a/frontend/views/layouts/application.html.erb
+++ b/frontend/views/layouts/application.html.erb
@@ -47,7 +47,6 @@
   <%= umd_lib_environment_banner %>
   <div class="container-fluid center-block">
     <header>
-      <%= render "shared/browser_support" %>
       <%= render "shared/header_global" %>
       <%= render "site/branding" %>
     </header>


### PR DESCRIPTION
Browser support check was [dropped in v2.1.0](
https://github.com/archivesspace/archivesspace/commit/2cac094f3b508d472ee3f154cbe3138b46889482)

This removes the call to that partial ( that was removed )

https://issues.umd.edu/browse/LIBASPACE-89