### PR TITLE
LIBASPACE-121. Use EAD location, if present, as citation URL.

### DIFF
--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -1,1 +1,12 @@
 require_relative '../umd_lib_environment_banner_helper'
+
+# insert our custom cite_url_and_timestamp method into the Record class
+# to display the EAD location (if present); falls back to the ASpace PUI URL
+Rails.application.config.after_initialize do
+  Record.class_eval do
+    def cite_url_and_timestamp
+      url = @json['ead_location'] || "#{AppConfig[:public_proxy_url].sub(/^\//, '')}#{uri}"
+      "#{url}  #{I18n.t('accessed')}  #{Time.now.strftime("%B %d, %Y")}"
+    end
+  end
+end


### PR DESCRIPTION
Redefines the cite_url_and_timestamp method of the Record class to use the EAD location (i.e., handle) as the citation URL. If there is no EAD location for a record, it falls back to the ASpace default of using the PUI URL of the resource.

https://issues.umd.edu/browse/LIBASPACE-121