### PR TITLE
LIBASPACE-127 Get the short name and not the FQDN for environment name

### DIFF
--- a/umd_lib_environment_banner_helper.rb
+++ b/umd_lib_environment_banner_helper.rb
@@ -2,7 +2,7 @@ require 'socket'
 
 module UMDLibEnvironmentBannerHelper
 
-  @@environment_name = case Socket.gethostname
+  @@environment_name = case Socket.gethostname.split(".").first
                        when /local$/
                         'Local'
                        when /dev$/


### PR DESCRIPTION
Need to check environment name on the 'short name' ( name before first
dot ), and not the FQDN

https://issues.umd.edu/browse/LIBASPACE-127