### PR TITLE
LIBASPACE-137. Added "Make a Gift" link to UMD wrapper

### DIFF
--- a/public/views/layouts/application.html.erb
+++ b/public/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
 	<% end %>
 
   <!-- UMD Wrapper -->
-  <script src="https://umd-header.umd.edu/build/bundle.js?search=0&amp;search_domain=&amp;events=0&amp;news=0&amp;schools=0&amp;admissions=0&amp;support=0&amp;support_url=&amp;wrapper=&amp;sticky=0"></script>
+  <script src="https://umd-header.umd.edu/build/bundle.js?search=0&amp;search_domain=&amp;events=0&amp;news=0&amp;schools=0&amp;admissions=0&amp;support=1&amp;support_url=https%253A%252F%252Fgiving.umd.edu%252Fgiving%252FshowSchool.php%253Fname%253Dlibraries&amp;wrapper=1160&amp;sticky=0"></script>
 
   <% if AppConfig.has_key?(:public_google_analytics_code) && !AppConfig[:public_google_analytics_code].empty? %>
     <!-- Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
On the "UMD Header Generator" page

   https://umd-header.umd.edu/generator/

used the following values in the fields:

* Include "Make A Gift" Link: Checked
* Make A Gift URL: "https://giving.umd.edu/giving/showSchool.php?name=libraries"
* Inner Wrapper Width, in pixels: 1160

The inner wrapper width was chosen to match the inner wrapper width on
the UMD Libraries home page (http://www.lib.umd.edu/).

In the resulting code, replaced all the "&" characters with "&amp;"

https://issues.umd.edu/browse/LIBASPACE-137