### PR TITLE
LIBASPACE-139. Changed search placeholder to "Search Within Collection"

### DIFF
--- a/public/assets/stylesheets/umd_lib.css
+++ b/public/assets/stylesheets/umd_lib.css
@@ -60,3 +60,11 @@ h1, h2, h3, h4, h5, h6 {
 .panel-footer .logo{
 	height: 50px;
 }
+
+#sidebar .search .form-group {
+  width: 100%;
+}
+
+#sidebar .search .form-group #filter_q0 {
+  width: 100%;
+}

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -1,3 +1,5 @@
 en:
-    brand:
-        title: Archival Collections
+  brand:
+    title: Archival Collections
+  actions:
+    search_in: "Search Within %{type}"


### PR DESCRIPTION
Overrode "actions.search_in" I18N resource from stock ArchivesSpace
using "public/locales/en.yml" file.

Also changed the spacing in the en.yml file to use 2 spaces for
indentation, instead of 4, both to match the style in stock
ArchivesSpace, and Ruby style.

Added CSS to adjust the width of the form group and "Search" textfield
to the full width of the sidebar, so that the placeholder text would
not be truncated.

Note: The change to the "actions.search_in" resource also changes
the HTML title (displayed in a browser tab).

https://issues.umd.edu/browse/LIBASPACE-139