### PR TITLE
LIBASPACE-136. Fixed location of filter sidebar.

### DIFF
--- a/public/views/search/search_results.html.erb
+++ b/public/views/search/search_results.html.erb
@@ -55,23 +55,22 @@
 </div>
 
 <% if defined?(@results) %>
-<div class="row">
-  <div class="col-sm-9">
-    <a name="main" title="<%= t('internal_links.main') %>"></a>
-    <div class="row">
-      <div class="col-sm-9">
-        <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
-      </div>
-      <div class="col-sm-3 text-right sorter">
+  <div class="row">
+    <div class="col-sm-9">
+      <a name="main" title="<%= t('internal_links.main') %>"></a>
+      <div class="row">
+        <div class="col-sm-9">
+          <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
+        </div>
         <%= render partial: 'shared/sorter' %>
       </div>
-    </div>
-    <div class="row search-results">
-      <div class="col-sm-12">
-        <a name="searchresults" id="searchresults"></a>
-        <% @results.records.each do |result| %>
-          <%= render partial: 'shared/result', locals: {:result => result, :props => (@result_props || {}).merge({:full => false})} %>
-        <% end %>
+      <div class="row search-results">
+        <div class="col-sm-12">
+          <a name="searchresults" id="searchresults"></a>
+          <% @results.records.each do |result| %>
+            <%= render partial: 'shared/result', locals: {:result => result, :props => (@result_props || {}).merge({:full => false})} %>
+          <% end %>
+        </div>
       </div>
       <div class="row">
         <div class="col-sm-12">
@@ -79,10 +78,9 @@
         </div>
       </div>
     </div>
+    <div class="col-sm-3">
+      <a name="filter" title="<%= t('internal_links.filter') %>"></a>
+      <%= render partial: 'shared/facets' %>
+    </div>
   </div>
-</div>
-<div class="col-sm-3">
-  <a name="filter" title="<%= t('internal_links.filter') %>"></a>
-  <%= render partial: 'shared/facets' %>
-</div>
 <% end %>


### PR DESCRIPTION
The filter div was outside of the proper row, so it was appearing at the bottom of the page instead of as a column to the right.

https://issues.umd.edu/browse/LIBASPACE-136