### PR TITLE
LIBASPACE-130. Fix home page title.

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   brand:
     title: Archival Collections
+    welcome_page_title: ''
     
   actions:
     search_in: "Search Within %{type}"


### PR DESCRIPTION
Set home page title to empty string, so only the brand title ("Archival Collections") is use on the home page.

https://issues.umd.edu/browse/LIBASPACE-130