### PR TITLE
LIBASPACE-107. Merged "actions" resources under single subtree

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -1,9 +1,10 @@
 en:
   brand:
     title: Archival Collections
-    
+
   actions:
     search_in: "Search Within %{type}"
+    hierarch: Collection Contents
 
   repository:
     _singular: Library
@@ -32,8 +33,6 @@ en:
   internal_links:
     collection: Collection Contents
 
-  actions:
-    hierarch: Collection Contents
 
   external_docs: Inventories/Additional Information
 


### PR DESCRIPTION
Combined the "actions.search_in" and "actions.hierarch" resources
under a single "actions" parent, as apparently YAML doesn't like
multiple instance of a parent and takes the last one.

https://issues.umd.edu/browse/LIBASPACE-107