### PR TITLE
LIBASPACE-138. Moved "Found in" over "Overview" summary in search res…

### DIFF
--- a/public/views/shared/_result.html.erb
+++ b/public/views/shared/_result.html.erb
@@ -4,6 +4,32 @@
    <div class="recordrow" style="clear:both" data-uri="<%= result.uri %>">
      <% end %>
      <%= render partial: 'shared/idbadge', locals: {:result => result, :props => props } %>
+
+    <% if result.resolved_repository %>
+      <div class="result_context" style="clear:both">
+        <strong><%= t('context') %>: </strong>
+        <span  class="repo_name">
+          <%= link_to result.resolved_repository.fetch('name'), app_prefix(result.resolved_repository.fetch('uri')) %>
+        </span>
+
+        <% if result.respond_to?(:ancestors) && result.ancestors %>
+          <% result.ancestors.each do |ancestor| %>
+            /
+            <span class="ancestor">
+            <%= link_to process_mixed_content(ancestor.fetch('title', "[#{ ancestor.fetch('level', 'untitled')}]" )).html_safe, app_prefix(ancestor.fetch('uri')) %>
+            </span>
+          <% end %>
+        <% else %>
+          <% unless props.fetch(:no_res, false) || result.resolved_resource.blank? %>
+            /
+            <span class="resource_name">
+              <%= link_to process_mixed_content(result.resolved_resource.fetch('title')).html_safe, app_prefix(result.resolved_resource.fetch('uri')) %>
+            </span>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+
      <div class="recordsummary" style="clear:both">
        <% if !result['parent_institution_name'].blank? %>
        <div><strong><%= t('parent_inst') %>:</strong>
@@ -38,32 +64,6 @@
 	  end
        %>
     <% end %>
-
-    <% if result.resolved_repository %>
-      <div class="result_context">
-        <strong><%= t('context') %>: </strong>
-        <span  class="repo_name">
-          <%= link_to result.resolved_repository.fetch('name'), app_prefix(result.resolved_repository.fetch('uri')) %>
-        </span>
-
-        <% if result.respond_to?(:ancestors) && result.ancestors %>
-          <% result.ancestors.each do |ancestor| %>
-            /
-            <span class="ancestor">
-            <%= link_to process_mixed_content(ancestor.fetch('title', "[#{ ancestor.fetch('level', 'untitled')}]" )).html_safe, app_prefix(ancestor.fetch('uri')) %>
-            </span>
-          <% end %>
-        <% else %>
-          <% unless props.fetch(:no_res, false) || result.resolved_resource.blank? %>
-            /
-            <span class="resource_name">
-              <%= link_to process_mixed_content(result.resolved_resource.fetch('title')).html_safe, app_prefix(result.resolved_resource.fetch('uri')) %>
-            </span>
-          <% end %>
-        <% end %>
-      </div>
-    <% end %>
-
 
        <% if !props.fetch(:full,false)  && result['primary_type'] == 'repository' %>
        <div><strong><%= t('number_of', { :type => t('resource._plural') }) %></strong> <%= @counts[result.uri]['resource'] %></div>


### PR DESCRIPTION
…ults

Switched the code so that the "Found in" section in the search results
(which displays the repository name) is displayed before the "Overview"
section (which displays the abstract for the respository).

Note: Needed to add 'style="clear:both"' to the "result_context" class,
in order for the text to be laid out properly.

https://issues.umd.edu/browse/LIBASPACE-138