### PR TITLE
LIBASPACE-148. Improved Google Analytics parameter handling

### DIFF
--- a/public/views/layouts/application.html.erb
+++ b/public/views/layouts/application.html.erb
@@ -61,14 +61,15 @@
   <!-- UMD Wrapper -->
   <script src="https://umd-header.umd.edu/build/bundle.js?search=0&amp;search_domain=&amp;events=0&amp;news=0&amp;schools=0&amp;admissions=0&amp;support=1&amp;support_url=https%253A%252F%252Fgiving.umd.edu%252Fgiving%252FshowSchool.php%253Fname%253Dlibraries&amp;wrapper=1160&amp;sticky=0"></script>
 
-  <% if AppConfig.has_key?(:public_google_analytics_code) && !AppConfig[:public_google_analytics_code].empty? %>
+  <% google_analytics_code = AppConfig[:public_google_analytics_code] if AppConfig.has_key?(:public_google_analytics_code) %>
+  <% unless (google_analytics_code.nil? || google_analytics_code.empty?) %>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= AppConfig[:public_google_analytics_code] %>"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= google_analytics_code %>"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '<%= AppConfig[:public_google_analytics_code] %>');
+      gtag('config', '<%= google_analytics_code %>');
     </script>
   <% end %>
 


### PR DESCRIPTION
Changed the code to verify that the value returned by AppConfig for the
Google Analytics Tag is not nil or empty, before using it to generate
the HTML.

https://issues.umd.edu/browse/LIBASPACE-148