### PR TITLE
LIBASPACE-120. Added "Help" menu to navigation bar

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -44,3 +44,5 @@ en:
   agent:
     _singular: Person
     _plural: People
+
+  help_tab: Help

--- a/public/views/shared/_navigation.html.erb
+++ b/public/views/shared/_navigation.html.erb
@@ -13,6 +13,9 @@
           <% $MAIN_MENU.each do |link| %>
             <li><a href="<%= app_prefix(link[0]) %>"><%= t(link[1]) %></a></li>
           <% end %>
+
+          <li><a href="https://www.lib.umd.edu/special/archivesspace"><%= I18n.t('help_tab') %></a></li>
+
           <% unless AppConfig[:pui_hide][:search_tab] %>
             <li>
               <%= link_to({:controller => :search, :action => :search, :reset => 'true'}, {:title => I18n.t('search_tab', :target => t('archive._plural'))}) do %>


### PR DESCRIPTION
Implemented in the simplest possible way, as it didn't seem like
something that would change often.

Used "help_tab" in I18N en.yml, following the "search_tab" I18N naming.

https://issues.umd.edu/browse/LIBASPACE-120