### PR TITLE
LIBASPACE-204. Miscellaneous label changes

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -5,7 +5,8 @@ en:
 
   actions:
     search_in: "Search Within %{type}"
-    hierarch: Collection Contents
+    hierarch: Finding Aid View
+    numeric: Box List
 
   repository:
     _singular: Library
@@ -57,6 +58,7 @@ en:
 
 
   external_docs: Inventories/Additional Information
+  cont_arr: Navigate the Collection
 
   all_agents: People
 


### PR DESCRIPTION
On a resource detail page, changed the following:

* In the blue tab bar, changed "Collection Contents" to "Finding Aid View"
* In the blue tab bar, changed "Container Inventory" label to "Box List"
* In the right sidebar, changed "Collection organization" header
  (below the "Search" button") to "Navigate the Collection".

https://issues.umd.edu/browse/LIBASPACE-204