### PR TITLE
LIBASPACE-205. Change collapse/expand indicators chevron to plus/minus

### DIFF
--- a/public/assets/stylesheets/umd_lib.css
+++ b/public/assets/stylesheets/umd_lib.css
@@ -117,3 +117,16 @@ h1, h2, h3, h4, h5, h6 {
 .navbar-nav>li>form button {
     color: #004f6f;
 }
+
+.largetree-container .expandme > .glyphicon-chevron-right:before {
+    content: "\002b"
+}
+
+.largetree-container .expandme > .glyphicon-chevron-right.expanded:before {
+    content: "\2212"
+}
+
+.largetree-container .expandme-icon.expanded {
+    transform: none;
+    transition: none;
+}


### PR DESCRIPTION
Change the "collapse/expand" chevron in the navigation tree to a
"plus" (when collapsed) and "minus" (when expanded).

https://issues.umd.edu/browse/LIBASPACE-205