### PR TITLE
LIBASPACE-210. Request instructions now display consistently

### DIFF
--- a/public/assets/stylesheets/umd_lib.css
+++ b/public/assets/stylesheets/umd_lib.css
@@ -210,3 +210,15 @@ h1, h2, h3, h4, h5, h6 {
     transform: none;
     transition: none;
 }
+
+.request_instructions {
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+  color: #31708f;
+  padding: 15px;
+  margin-bottom: 20px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  font-weight: bold;
+}

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -77,3 +77,6 @@ en:
   search:
     header:
       label: Find what you are looking for
+
+  collections:
+    request_instructions: Use the right side menu to identify relevant boxes and place requests.

--- a/public/views/objects/show.html.erb
+++ b/public/views/objects/show.html.erb
@@ -1,0 +1,41 @@
+<%= render partial: 'shared/request_instructions' %>
+
+<a name="main" title="<%= t('internal_links.main') %>"></a>
+<div id="main-content" class="row objects">
+  <div class="row" id="info_row">
+    <div class="information col-sm-7">
+      <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
+    </div>
+    <div class="page_actions col-sm-5 right">
+    <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath, :cite => @result.cite } %>
+    </div>
+  </div>
+
+  <%= render partial: 'shared/breadcrumbs' %>
+
+  <div class="row" id="notes_row">
+   <div class="col-sm-9">
+    <% if  defined?(comp_id) && !comp_id && !@result['json']['ref_id'].blank? %>
+      <span class='ref_id'>[<%=  t('archival_object._public.header.ref_id') %>: <%= @result['json']['ref_id'] %>]</span>
+    <% end %>
+    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig} %>
+
+    <%= render partial: 'shared/record_innards' %>
+   </div>
+
+   <% if !@result.instance_of?(DigitalObject) || @has_children %>
+    <div id="sidebar" class="sidebar sidebar-container col-sm-3 resizable-sidebar">
+      <%
+        if @result.kind_of?(DigitalObject)
+          heading_text = t('dig_cont_arr')
+        else
+          heading_text = t('cont_arr')
+        end
+      %>
+      <%= render partial: 'shared/children_tree', :locals => {:heading_text => heading_text, :root_node_uri => @result.root_node_uri, :current_node_uri => @result.uri} %>
+    </div>
+   <% end %>
+  </div>
+ <%= render partial: 'shared/modal_actions' %>
+</div>
+

--- a/public/views/resources/show.html.erb
+++ b/public/views/resources/show.html.erb
@@ -1,0 +1,63 @@
+<%= render partial: 'shared/request_instructions' %>
+
+<a name="main" title="<%= t('internal_links.main') %>"></a>
+<div id="main-content" class="row resources">
+  <div class="row" id="info_row">
+  <% unless defined?(@no_statement) || !defined?(@search) %>
+  <div class="searchstatement"><%= @search[:search_statement].html_safe %></div>
+  <% end %>
+  </div>
+  <div class="information col-sm-7">
+      <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
+  </div>
+  <div class="page_actions col-sm-5 right">
+    <%= render partial: 'shared/page_actions', locals: {:record => @result, :title =>  @result.display_string, :url => request.fullpath, :cite => @result.cite } %>
+  </div>
+</div>
+<div class="row">
+    <%= render partial: 'shared/breadcrumbs' %>
+</div>
+
+<%= render partial: 'resources/resource_alltabs' %>
+
+<div class="row" id="notes_row">
+  <div class="col-sm-9">
+    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig} %>
+    <%= render partial: 'shared/record_innards' %>
+  </div>
+  <div id="sidebar" class="col-sm-3 sidebar sidebar-container resizable-sidebar" <% unless @has_children %>style="display: none"<% end %>>
+    <% if defined?(@filters) && defined?(@search) %>
+    <%= render partial: 'shared/facets' %>
+   <% end %>
+
+   <a name="search" title="<%= t('internal_links.search_collection') %>"></a>
+    <div class="search">
+
+	<%= form_tag(app_prefix("#{@result['uri']}/search"), method: 'get', :class=> "form-inline") do %>
+	<div class="form-group">
+	  <%= label_tag(:filter_q0,  "#{t('actions.search_in', :type=> t('resource._singular'))}", :class => 'sr-only') %>
+
+          <%= text_field_tag('filter_q[]', nil,:id => 'filter_q0', :placeholder =>  "#{t('actions.search_in', :type => t('resource._singular'))}", :class=> "form-control") %>
+	</div>
+	<div class="form-group">
+	  <%= hidden_field_tag('op[]','') %>
+	  <%= hidden_field_tag('field[]','') %>
+	  <%= hidden_field_tag('limit','') %>
+	  <%= hidden_field_tag('q[]','*') %>
+
+	  <span class="inline-label"><%= t('search_results.filter.years') %>:</span>
+	   <%= label_tag(:from_year0, "#{t('search_results.filter.from_year')}", :class => 'sr-only') %>
+	   <%= text_field_tag('from_year[]', nil, :id=>'from_year0', :size => 4,:maxlength => 4, :placeholder => t('search_results.filter.from'),
+            :class=>"form-control") %> <span class="inline-label"><%= t('search_results.filter.to') %></span> <%= label_tag(:to_year0, "#{t('search_results.filter.to_year')}", :class=> 'sr-only') %>
+	   <%= text_field_tag('to_year[]', nil, :size => 4, :maxlength => 4, :class=> "form-control", :id => 'to_year0',
+           :placeholder => t('search_results.filter.to')) %>
+	</div>
+        <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary btn-sm') %>
+	<% end %>
+    </div>
+
+    <%= render partial: 'shared/children_tree', :locals => {:heading_text => t('cont_arr'), :root_node_uri => @result.uri, :current_node_uri => @result.uri} %>
+  </div>
+</div>
+
+<%= render partial: 'shared/modal_actions' %>

--- a/public/views/shared/_request_instructions.html.erb
+++ b/public/views/shared/_request_instructions.html.erb
@@ -1,0 +1,3 @@
+<div class="request_instructions">
+  <%= t('collections.request_instructions') %>
+</div>


### PR DESCRIPTION
Modified request instructions for "collections" objects
so that the instructions are displayed as part of the template, not
via Rails "flash" messages.

Added "public/views/shared/_request_instructions.html.erb" as a view
helper that can be added where needed to display the instructions.

Added the view helper to the "show" templates for "objects" and
"resources", which were copied from the v2.2.2 ArchivesSpace codebase.

Modified CSS to style the request instructions so that it appears
similar to the Rails "informational" flash notices (this will likely
be changed in the future).

Updated the wording for the request instructions as specified in
LIBASPACE-211, and made displayed in bold as specified in LIBASPACE-213.

https://issues.umd.edu/browse/LIBASPACE-210