### PR TITLE
LIBASPACE-117. Navigation search textbox formatting updates

### DIFF
--- a/public/assets/stylesheets/umd_lib.css
+++ b/public/assets/stylesheets/umd_lib.css
@@ -13,10 +13,25 @@
     margin:0 0 0 0;
 }
 
+.website-feedback{
+	margin: 5px 0;
+}
+
 #header .website-feedback-link:hover {
     text-decoration: underline;
 }
 
+.navbar .navbar-header .navbar-toggle {
+	background: #fff;
+}
+.navbar-default .navbar-collapse, .navbar-default .navbar-form {
+    border: none;
+}
+.navbar-toggle {
+	float: left;
+	padding: 8px 6px;
+	margin-left: 10px;
+}
 /* Custom pull-right that only occurs at medium or higher, see
    https://stackoverflow.com/a/19405414 */
 @media (min-width: 992px) {
@@ -44,7 +59,7 @@
     border: 1px solid #eee;
     background: #fff none repeat scroll 0 0;
 }
-p a, l a, div a, .app-title {
+p, a, l a, div a, .app-title {
     font-weight: 500;
 }
 .panel-footer a,.panel-footer a:hover,.panel-footer a:active {
@@ -68,14 +83,30 @@ p a, l a, div a, .app-title {
 }
 .navbar {
     position: relative;
-    min-height: 40px;
+    min-height: 35px;
     margin-bottom: 0;
 }
 .navbar-default .navbar-nav>li>a {
     color: #fff;
+    font-size: 13px !important;
 }
 .navbar-default .navbar-nav>li>a:hover {
     color: #f0ad4e;
+}
+.umd-search {
+ 	height: 24px;
+}
+.umd-search-btn {
+    background-color: #a40404;
+    border-color: #a40404;
+	padding-top: 2px;
+	height: 24px;
+	color: #fff;
+}
+.navbar-form {
+	margin: 3px 5px;
+	float: right;
+
 }
 h1, h2, h3, h4, h5, h6 {
     color: #a40404;
@@ -140,8 +171,8 @@ h1, h2, h3, h4, h5, h6 {
 /* Sticky footer */
 
 .site {
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
     height: 100vh;
     display: -webkit-box;
     display: -webkit-flex;
@@ -182,7 +213,16 @@ h1, h2, h3, h4, h5, h6 {
     color: #004f6f;
 }
 
+@media (max-width: 767px) {
+  #navigation.container {
+  margin-left: -1px;
+  margin-right: -1px;
+}
+}
 @media (min-width: 768px){
+.website-feedback {
+	float: right;
+}
 .navbar-nav>li>a {
     padding-top: 5px;
     padding-bottom: 5px;
@@ -192,9 +232,21 @@ h1, h2, h3, h4, h5, h6 {
 }
 }
 
+@media (min-width:480px){
+.visible-xxs{
+    display: none !important;
+}
+}
+
 @media (max-width: 479px){
 .app-title {
-    font-size: 24px;
+    font-size: 22px;
+}
+.hidden-xxs{
+    display: none !important;
+}
+.visible-xxs{
+    display: block !important;
 }
 }
 

--- a/public/views/shared/_header.html.erb
+++ b/public/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <section  id="header">
   <div class="row">
-    <div class="col-md-2 col-sm-4 col-xs-4">
+    <div class="col-md-2 col-sm-3 col-xs-4">
       <a href="//lib.umd.edu" target="_blank"><img id="logo-header" class="img-responsive" width="170px" alt="University of Maryland Libraries Logo" src="<%= asset_url('/assets/images/liblogo.png') %>">    </a>
     </div>
     <div class="col-md-6 col-sm-5 col-xs-8">
@@ -10,8 +10,8 @@
         <a title="<%=t('brand.title_link_text') %>" href="<%= AppConfig[:public_proxy_url] %>" class="app-title"><%= t('brand.title') %></a>
       <% end %>
     </div>
-    <div class="col-md-4 col-sm-3 col-xs-12">
-      <div class="pull-right-md website-feedback">
+    <div class="col-md-4 col-sm-4 col-xs-12">
+      <div class="website-feedback">
         <p class="website-feedback-label">Help us improve our website</p>
         <a class="website-feedback-link" href="<%= AppConfig[:website_feedback_url] %>">Send feedback</a>
       </div>

--- a/public/views/shared/_navigation.html.erb
+++ b/public/views/shared/_navigation.html.erb
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <div class="collapse navbar-collapse" id="collapsemenu">
+      <div class="collapse navbar-collapse pull-left" id="collapsemenu">
         <ul class="nav nav navbar-nav">
           <%# TODO: add class="active" if we're on that page %>
           <% $MAIN_MENU.each do |link| %>
@@ -17,7 +17,6 @@
             <% end %>
             <li><a href="<%= link[0] %>"><%= t(link[1]) %></a></li>
           <% end %>
-
           <% unless AppConfig[:pui_hide][:search_tab] %>
             <li>
               <%= link_to({:controller => :search, :action => :search, :reset => 'true'}, {:title => I18n.t('search_tab', :target => t('archive._plural'))}) do %>
@@ -26,24 +25,17 @@
               <% end %>
             </li>
           <% end %>
-          <% unless AppConfig[:pui_hide][:search_box_tab] %>
-            <li>
-              <%= form_tag(url_for(:controller => :search, :action => :search), :method => 'get', :class => 'navbar-form') do %>
-                <%= hidden_field_tag 'op[]' %>
-                <div class="input-group">
-                  <%= text_field_tag 'q[]', nil, :class => 'form-control', :placeholder => 'Search across our collections, digital materials, and more.' %>
-                  <span class="input-group-btn">
-                    <%= button_tag(type: "submit", class: "btn btn-default") do %>
-                      <span class="fa fa-search" aria-hidden="true"></span>
-                      <span class="sr-only"><%= I18n.t('search_tab', :target => t('archive._plural')) %></span>
-                    <% end %>
-                  </span>
-                </div>
-              <% end %>
-            </li>
-          <% end %>
         </ul>
       </div>
+      <% unless AppConfig[:pui_hide][:search_box_tab] %>
+        <div class="pull-right hidden-xxs">
+          <%# Using search_box_id to prevent search form from having duplicate HTML ids %>
+          <%= render partial: 'shared/navigation_search', locals: {search_box_id: '1'} %>
+        </div>
+        <div class="visible-xxs">
+          <%= render partial: 'shared/navigation_search', locals: {search_box_id: '2'} %>
+        </div>
+      <% end %>
     </div>
   </nav>
 </section>

--- a/public/views/shared/_navigation_search.html.erb
+++ b/public/views/shared/_navigation_search.html.erb
@@ -1,0 +1,13 @@
+<%= form_tag(url_for(:controller => :search, :action => :search), :method => 'get', :class => 'navbar-form') do %>
+  <%# Using local parameter "search_box_id" to prevent search form from having duplicate HTML ids %>
+  <%= hidden_field_tag 'op[]', nil, id: "op_#{search_box_id}" %>
+  <div class="input-group">
+    <%= text_field_tag 'q[]', nil, id: "q_#{search_box_id}", :class => 'form-control umd-search', :placeholder => I18n.t('actions.search') %>
+    <span class="input-group-btn">
+      <%= button_tag(type: "submit", class: "btn btn-default umd-search-btn") do %>
+        <span class="fa fa-search" aria-hidden="true"></span>
+        <span class="sr-only"><%= I18n.t('search_tab', :target => t('archive._plural')) %></span>
+      <% end %>
+    </span>
+  </div>
+<% end %>


### PR DESCRIPTION
Modified the search textbox in the navigation bar to match mockup at
https://umd-lib.github.io/mockups/aspace/home-letter.htm,
including RWD behavior.

Moved search textbox and button into separate helper, because it is
added twice in the page for RWD handling. Added a local parameter
"search_box_id" that gets passed into the helper to distinguish
the HTML ids used in the form tags.

https://issues.umd.edu/browse/LIBASPACE-117