### PR TITLE
LIBASPACE-276. Removed extraneous "Library" from "Library Details" panel

### DIFF
--- a/public/views/repositories/_repository_details.html.erb
+++ b/public/views/repositories/_repository_details.html.erb
@@ -1,0 +1,3 @@
+<h2><%= t('repository.details') %></h2>
+<p> <%= "#{t('repository.part')} #{@repo_info['top']['name']}" %></p>
+<%= render partial: 'repositories/full_repo', locals: {:info => @repo_info, :url => @repo_info['top']['url']} %>


### PR DESCRIPTION
Removed an extraneous "Library" form the "Library Details" panel
("Repository Details" panel in stock ArchivesSpace), as the repository
name in the "name" field of the "repository" database table
already includes "Library" (or "Archives").

https://issues.umd.edu/browse/LIBASPACE-276