### PR TITLE
LIBASPACE-283. Enable environment banner to be controlled via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,76 @@
 # umd-lib-aspace-theme
 
 ArchivesSpace plugin for UMD Libraries theme elements
+
+## Environment Banner
+
+Per the SSDR policy specified in https://confluence.umd.edu/display/LIB/Create+Environment+Banners
+an environment banner should be shown on all non-production systems.
+
+The display of the environment banner is handled by the
+UMDLibEnvironmentBannerHelper module, which uses one of two mechanisms to
+determine the banner to display:
+
+* Environment variables
+* Hostname/Rails environment
+
+The environment variables, if specified, take precedence over the hostname
+banner.
+
+### Environment variables
+
+The text and color of the banner can be controlled by the following environment
+variables:
+
+* ENVIRONMENT_BANNER - The text to display
+* ENVIRONMENT_BANNER_BACKGROUND - The background color of the banner, expressed
+as a CSS color (i.e., "#ff0000" for red).
+* ENVIRONMENT_BANNER_FOREGROUND - The foreground (text) color of the banner,
+expressed as a CSS color (i.e., "#ff0000" for red).
+* ENVIRONMENT_BANNER_ENABLED - optional parameter. If set to "false" the banner
+will not be displayed.
+
+## Hostname/Rails environment
+
+Determines the banner to display based on the hostname or Rails environment.
+
+Sets the banner to the following environments:
+
+* Local - if hostname matches "local" or Rails.env.development?, or
+Rails.env.vagrant? return true
+* Development - if hostname matches "dev"
+* Staging - if hostname matches "stage"
+
+A hostname matches if the first segment of the hostname ends with the given
+string, i.e. "foo-dev.example.com", "foo-dev", and "dev" all match for
+"Development".
+
+## Running the Tests
+
+The ArchivesSpace build script does not appear to be correctly configured to
+run unit tests in the "plugins" directory.
+
+To enable ArchivesSpace to run the tests:
+
+1) Edit the "build/build.xml" file, changing the "plugin:frontend:test" by
+adding/changing the following lines:
+
+```
+  <target name="plugin:frontend:test" depends="set-classpath" description="Run the unit test suite">
+    ...
+    <dirset id="plugins" dir="../plugins">
+      ...
+    </dirset>
+    <pathconvert pathsep=" " property="plugin-spec-dirs" refid="plugins"/>
+    <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true"
+      ...
+      <arg line="../build/gems/bin/rspec -b --format d -P '*_spec.rb' --order rand:1 ${example-arg} spec/${spec} ${plugin-spec-dirs}" />
+    </java>
+  </target>
+```
+
+2) The tests can then be run using the following command:
+
+```
+> build/run plugin:frontend:test
+```

--- a/frontend/spec/banner_spec.rb
+++ b/frontend/spec/banner_spec.rb
@@ -1,0 +1,189 @@
+require 'rails'
+require 'socket'
+require 'spec_helper'
+require 'rails_helper'
+require_relative '../../umd_lib_environment_banner_helper.rb'
+
+# Resets the UMDLibEnvironmentBannerHelper, which is needed because the
+# banner HTML is typically only generated when the module is initialized.
+def reset_banner_helper
+  UMDLibEnvironmentBannerHelper.class_variable_set :@@banner_initialized, false
+  # Object.send(:remove_const, :UMDLibEnvironmentBannerHelper)
+  # load '../../umd_lib_environment_banner_helper.rb'
+end
+
+# Helper class to enable banner use in tests
+class TestBannerHelper
+  include UMDLibEnvironmentBannerHelper
+end
+
+describe UMDLibEnvironmentBannerHelper do
+  it 'returns the proper banner based on hostname/environment variables' do
+    ENV.clear
+
+    # Hostname banner - Local
+    reset_banner_helper
+    test_banner_helper = TestBannerHelper.new
+    allow(Socket).to receive(:gethostname).and_return("test-local")
+    html = test_banner_helper.umd_lib_environment_banner
+    expect(html).to eq("<div class='environment-banner' id='environment-local'>Local Environment</div>")
+
+    # Hostname banner - Development
+    reset_banner_helper
+    allow(Socket).to receive(:gethostname).and_return("test-dev")
+    html = test_banner_helper.umd_lib_environment_banner
+    expect(html).to eq("<div class='environment-banner' id='environment-development'>Development Environment</div>")
+
+    # Hostname banner - Staging
+    reset_banner_helper
+    allow(Socket).to receive(:gethostname).and_return("test-stage")
+    html = test_banner_helper.umd_lib_environment_banner
+    expect(html).to eq("<div class='environment-banner' id='environment-staging'>Staging Environment</div>")
+
+    # Hostname banner - Production (No banner)
+    reset_banner_helper
+    allow(Socket).to receive(:gethostname).and_return("test-production")
+    html = test_banner_helper.umd_lib_environment_banner
+    expect(html).to eq(nil)
+
+    # Environment variable-based bannner
+    reset_banner_helper
+    allow(Socket).to receive(:gethostname).and_return("test-stage")
+    ENV['ENVIRONMENT_BANNER'] = 'Test Banner'
+    html = test_banner_helper.umd_lib_environment_banner
+    expect(html).to eq("<div class='environment-banner'>Test Banner</div>")
+
+    # Environment variable-based bannner
+    reset_banner_helper
+    allow(Socket).to receive(:gethostname).and_return("test-stage")
+    ENV['ENVIRONMENT_BANNER'] = 'Test Banner'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#000000'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ffffff'
+    html = test_banner_helper.umd_lib_environment_banner
+    expect(html).to eq("<div class='environment-banner' style='background-color: #000000; color: #ffffff;'>Test Banner</div>")
+
+    # ENVIRONMENT_BANNER_ENABLED takes precedence
+    reset_banner_helper
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'false'
+    allow(Socket).to receive(:gethostname).and_return("test-stage")
+    html = test_banner_helper.umd_lib_environment_banner
+    expect(html).to eq(nil)
+  end
+end
+
+describe UMDLibEnvironmentBannerHelper::EnvVarsEnvironmentBanner do
+  it 'returns an environment banner based on ENV variables' do
+    ENV.clear
+
+    ENV['ENVIRONMENT_BANNER'] = 'Test Banner'
+
+    banner = UMDLibEnvironmentBannerHelper::EnvVarsEnvironmentBanner.new
+
+    expect(banner.text).to eq('Test Banner')
+    expect(banner.enabled?).to eq(true)
+    expect(banner.css_options.size).to eq(1)
+    expect(banner.css_options[:class]).to eq('environment-banner')
+
+    ENV['ENVIRONMENT_BANNER'] = 'Test Banner'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#000000'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ffffff'
+
+    banner = UMDLibEnvironmentBannerHelper::EnvVarsEnvironmentBanner.new
+
+    expect(banner.text).to eq('Test Banner')
+    expect(banner.enabled?).to eq(true)
+    expect(banner.css_options.size).to eq(2)
+    expect(banner.css_options[:class]).to eq('environment-banner')
+    expect(banner.css_options[:style]).to eq('background-color: #000000; color: #ffffff;')
+  end
+
+  it 'is disabled, if no ENVIRONMENT_BANNER environment variable is provided' do
+    ENV.clear
+
+    banner = UMDLibEnvironmentBannerHelper::EnvVarsEnvironmentBanner.new
+    expect(banner.enabled?).to eq(false)
+
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#000000'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ffffff'
+
+    banner = UMDLibEnvironmentBannerHelper::EnvVarsEnvironmentBanner.new
+
+    expect(banner.enabled?).to eq(false)
+  end
+
+  it 'is disabled, if ENVIRONMENT_BANNER_ENABLED environment variable is false' do
+    ENV.clear
+
+    banner = UMDLibEnvironmentBannerHelper::EnvVarsEnvironmentBanner.new
+    expect(banner.enabled?).to eq(false)
+
+    ENV['ENVIRONMENT_BANNER'] = 'Test Banner'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#000000'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ffffff'
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'false'
+
+    banner = UMDLibEnvironmentBannerHelper::EnvVarsEnvironmentBanner.new
+
+    expect(banner.enabled?).to eq(false)
+  end
+
+end
+
+describe UMDLibEnvironmentBannerHelper::HostEnvironmentBanner do
+  it 'returns an environment banner based on hostname' do
+    ENV.clear
+
+    # Local
+    allow(Socket).to receive(:gethostname).and_return("test-local")
+    banner = UMDLibEnvironmentBannerHelper::HostEnvironmentBanner.new
+
+    expect(banner.text).to eq('Local Environment')
+    expect(banner.enabled?).to eq(true)
+    expect(banner.css_options.size).to eq(2)
+    expect(banner.css_options[:class]).to eq('environment-banner')
+    expect(banner.css_options[:id]).to eq('environment-local')
+
+    # Development
+    allow(Socket).to receive(:gethostname).and_return("test-dev")
+    banner = UMDLibEnvironmentBannerHelper::HostEnvironmentBanner.new
+
+    expect(banner.text).to eq('Development Environment')
+    expect(banner.enabled?).to eq(true)
+    expect(banner.css_options.size).to eq(2)
+    expect(banner.css_options[:class]).to eq('environment-banner')
+    expect(banner.css_options[:id]).to eq('environment-development')
+
+    # Stage
+    allow(Socket).to receive(:gethostname).and_return("test-stage")
+    banner = UMDLibEnvironmentBannerHelper::HostEnvironmentBanner.new
+
+    expect(banner.text).to eq('Staging Environment')
+    expect(banner.enabled?).to eq(true)
+    expect(banner.css_options.size).to eq(2)
+    expect(banner.css_options[:class]).to eq('environment-banner')
+    expect(banner.css_options[:id]).to eq('environment-staging')
+
+    # Rails development override hostname from Socket
+    allow(Socket).to receive(:gethostname).and_return("test-stage")
+    allow(Rails.env).to receive(:development?).and_return(true)
+    banner = UMDLibEnvironmentBannerHelper::HostEnvironmentBanner.new
+
+    expect(banner.text).to eq('Local Environment')
+    expect(banner.enabled?).to eq(true)
+    expect(banner.css_options.size).to eq(2)
+    expect(banner.css_options[:class]).to eq('environment-banner')
+    expect(banner.css_options[:id]).to eq('environment-local')
+
+    # Rails vagrant override hostname from Socket
+    allow(Socket).to receive(:gethostname).and_return("test-stage")
+    allow(Rails.env).to receive(:development?).and_return(false)
+    allow(Rails.env).to receive(:vagrant?).and_return(true)
+    banner = UMDLibEnvironmentBannerHelper::HostEnvironmentBanner.new
+
+    expect(banner.text).to eq('Local Environment')
+    expect(banner.enabled?).to eq(true)
+    expect(banner.css_options.size).to eq(2)
+    expect(banner.css_options[:class]).to eq('environment-banner')
+    expect(banner.css_options[:id]).to eq('environment-local')
+  end
+end

--- a/frontend/spec/rails_helper.rb
+++ b/frontend/spec/rails_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# This file is copied to spec/ when you run 'rails generate rspec:install'
+
+RSpec.configure do |config|
+  # RSpec Rails can automatically mix in different behaviours to your tests
+  # based on their file location, for example enabling you to call `get` and
+  # `post` in specs under `spec/controllers`.
+  #
+  # You can disable this behaviour by removing the line below, and instead
+  # explicitly tag your specs with their type, e.g.:
+  #
+  #     RSpec.describe UsersController, :type => :controller do
+  #       # ...
+  #     end
+  #
+  # The different available types are documented in the features, such as in
+  # https://relishapp.com/rspec/rspec-rails/docs
+  config.infer_spec_type_from_file_location!
+
+  # Filter lines from Rails gems in backtraces.
+  config.filter_rails_from_backtrace!
+  # arbitrary gems may also be filtered via:
+  # config.filter_gems_from_backtrace("gem name")
+end

--- a/frontend/spec/spec_helper
+++ b/frontend/spec/spec_helper
@@ -1,0 +1,1 @@
+require_relative '../../../../frontend/spec/spec_helper'

--- a/umd_lib_environment_banner_helper.rb
+++ b/umd_lib_environment_banner_helper.rb
@@ -1,27 +1,169 @@
 require 'socket'
+require 'rails'
 
+# Creates an environment banner (as specified in
+# https://confluence.umd.edu/display/LIB/Create+Environment+Banners)
 module UMDLibEnvironmentBannerHelper
+  @@banner_initialized = false
+  @@banner = nil
 
-  @@environment_name = case Socket.gethostname.split(".").first
-                       when /local$/
-                        'Local'
-                       when /dev$/
-                        'Development'
-                       when /stage$/
-                         'Staging'
-		                   end 
- 
-  def environment_name 
-   ( Rails.env.development? || Rails.env.vagrant? ) ? "Local" : @@environment_name
-  end
-  
-  # https://confluence.umd.edu/display/LIB/Create+Environment+Banners
-  def umd_lib_environment_banner
-    if environment_name
-      "<div class='environment-banner' id='environment-#{environment_name.downcase}'>#{environment_name} Environment</div>".html_safe
+  # Initializes the banner
+  def self.initialize
+    # Uses @@banner_initialized to skip regenerating banner each time the
+    # module is called.
+    if !@@banner_initialized
+      # The EnvVarsEnvironmentBanner banner is used, if enabled, otherwise
+      # defaults to the HostEnvironmentBanner implementation
+      banner = EnvVarsEnvironmentBanner.new
+      if !banner.enabled?
+        banner = HostEnvironmentBanner.new
+      end
+      @@banner = banner
+      @@banner_initialized = true
     end
+
+    @@banner
   end
 
+  # Returns the HTML to display for the banner, or nil if no banner should
+  # be displayed.
+  def umd_lib_environment_banner
+    if !@@banner_initialized
+      # Uses @@banner_initialized to skip regenerating HTML each time the
+      # method is called.
+      banner = UMDLibEnvironmentBannerHelper.initialize
+
+      # ENVIRONMENT_BANNER_ENABLED always takes precedence
+      if ENV['ENVIRONMENT_BANNER_ENABLED'] == 'false'
+        return @@banner_html = nil
+      end
+
+      if banner.enabled?
+        css_options = banner.css_options
+        # Sort to get consistent ordering of keys
+        css_string = css_options.sort.to_h.map { |key,value| "#{key}='#{value}'" }.join(" ")
+        banner_text = banner.text
+        @@banner_html = "<div #{css_string}>#{banner_text}</div>".html_safe
+        return @@banner_html
+      else
+        @@banner_html = nil
+      end
+    end
+    @@banner_html
+  end
+
+    # Returns an environment banner based on ENV config properties
+    class EnvVarsEnvironmentBanner
+      attr_accessor :text
+      attr_accessor :css_options
+
+      def initialize
+        @text = banner_text
+        @css_options = banner_css_options
+        @enabled = banner_enabled(@text)
+      end
+
+      # Returns the text to display in the environment banner.
+      #
+      # Implementation: Returns the value of the ENVIRONMENT_BANNER property, if
+      # non-empty.
+      #
+      # This method may return nil, if there is no ENVIRONMENT_BANNER
+      def banner_text
+        banner_text = ENV.has_key?('ENVIRONMENT_BANNER') ? ENV['ENVIRONMENT_BANNER'] : ''
+        if !banner_text.empty?
+           ENV['ENVIRONMENT_BANNER'].freeze
+        end
+      end
+
+      # Returns the CSS options to use with the environment banner.
+      #
+      # Implementation: Uses the ENVIRONMENT_BANNER_BACKGROUND and
+      # ENVIRONMENT_BANNER_FOREGROUND properties, if provided.
+      def banner_css_options
+        css_options = {}
+        css_style = ''
+
+        background_color = ENV.has_key?('ENVIRONMENT_BANNER_BACKGROUND') ? ENV['ENVIRONMENT_BANNER_BACKGROUND'] : ''
+        foreground_color = ENV.has_key?('ENVIRONMENT_BANNER_FOREGROUND') ? ENV['ENVIRONMENT_BANNER_FOREGROUND'] : ''
+
+        if !background_color.empty?
+          css_style = "background-color: #{background_color};"
+        end
+
+        if !foreground_color.empty?
+          css_style += " color: #{foreground_color};"
+          css_style.strip!
+        end
+
+        if !css_style.empty?
+          css_options[:style] = css_style
+        end
+
+        css_options[:class] = 'environment-banner'
+        css_options
+      end
+
+      # Returns true if the banner should be displayed, false otherwise.
+      #
+      # text - the text (if any) being displayedin the banner
+      def banner_enabled(text)
+        env_var_enabled = ENV['ENVIRONMENT_BANNER_ENABLED']
+        env_var_enabled = ENV.has_key?('ENVIRONMENT_BANNER_ENABLED') ? ENV['ENVIRONMENT_BANNER_ENABLED'] : ''
+
+        # Don't display the banner if there is no text
+        has_display_text = !text.nil? && !text.empty?
+        return false unless has_display_text
+
+        # Display if ENVIRONMENT_BANNER_ENABLED is not provided or empty
+        return true if env_var_enabled.nil? || env_var_enabled.empty?
+
+        # Any value other than "true" is false
+        env_var_enabled.strip.downcase == 'true'
+      end
+
+      def enabled?
+        @enabled
+      end
+    end
+
+  # Returns an environment banner based on host properties
+  class HostEnvironmentBanner
+    attr_accessor :text
+    attr_accessor :css_options
+
+    def initialize
+      environment_name = environment_name()
+      if environment_name.nil?
+        @enabled = false
+        return
+      end
+      @text = "#{environment_name} Environment"
+      @css_options = {}
+      @css_options[:id] = "environment-#{environment_name.downcase}"
+      @css_options[:class] = "environment-banner"
+      @enabled = !environment_name.empty?
+    end
+
+    def enabled?
+      @enabled
+    end
+
+    private
+
+      def environment_name
+        environment_name_from_host = case Socket.gethostname.split(".").first
+        when /local$/
+         'Local'
+        when /dev$/
+         'Development'
+        when /stage$/
+          'Staging'
+        end
+
+        ( Rails.env.development? || Rails.env.vagrant? ) ? "Local" : environment_name_from_host
+      end
+  end
 end
 
 # here we reopen the ApplicationController (after Rails has started)


### PR DESCRIPTION
Modified the UMDLibEnvironmentBannerHelper to enable the banner to be
controlled via environment variables.

Kept current implementation based on hostname, but enabled it to be
overridden by that environment variables.

https://issues.umd.edu/browse/LIBASPACE-283