### PR TITLE
LIBASPACE-337. Update "_only_facets.html.erb" for ArchivesSpace v3.3.1

### DIFF
--- a/public/views/shared/_only_facets.html.erb
+++ b/public/views/shared/_only_facets.html.erb
@@ -19,27 +19,27 @@
 
   <% ordered_facet_types.each do |type| %>
     <% next if type == 'subjects' %>
-    <% h = @facets.fetch(type, false) %>
-    <% next unless h %>
+    <% facet_group = @facets.fetch(type, false) %>
+
+    <% next if facet_group.empty? %>
     <dt><%= t("search_results.filter.#{type}") %></dt>
-    <% facet_count = 0 %>
-    <% h.each do |v, ct| %>
-      <% if facet_count == 5 %>
+    <% facet_group.each_with_index do |facet, i| %>
+      <% if i == 5 %>
         <div class="more-facets">
           <span class="more btn">&or; <%= t('search_results.more_facets') %></span>
           <div class="below-the-fold">
       <% end %>
-      <% facet_count += 1 %>
       <dd>
-        <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(v)}") %>"
-           title="<%= t('search_results.filter_by')%> '<%= get_pretty_facet_value(type,v) %>'">
-          <%= get_pretty_facet_value(type,v) %>
+        <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(facet.key)}") %>"
+           rel="nofollow"
+           title="<%= t('search_results.filter_by')%> '<%= facet.label %>'">
+          <%= facet.label %>
         </a>
-        <span class="recordnumber"><%= ct %></span>
+        <span class="recordnumber"><%= facet.count %></span>
       </dd>
     <% end %>
-    <% if facet_count > 5 %>
-        <span class="less btn">&and; <%= t('search_results.fewer_facets') %></span>
+    <% if facet_group.size > 5 %>
++        <span class="less btn">&and; <%= t('search_results.fewer_facets') %></span>
       </div>
     <% end %>
     <span class="type-spacer">&nbsp;</span>


### PR DESCRIPTION
Replaced "public/views/shared/_only_facets.html.erb" template with version from ArchivesSpace v3.3.1, and the modified as follows to restore UMD customizations:

* Removed "langcode" from the "preferred_facet_order". While this was probably never any intentional choice, this change was made to preserve the existing facet display order (the "langcode" facet is still displayed, it is just displayed after the "preferred" facets).
* The "subjects" (displayed as "Topic" in the GUI) in the facet is skipped (this is the intentional change made in LIBASPACE-152).

https://issues.umd.edu/browse/LIBASPACE-337