### PR TITLE
LIBASPACE-341. Commented out "+" button in search form

### DIFF
--- a/public/views/shared/_search.html.erb
+++ b/public/views/shared/_search.html.erb
@@ -40,7 +40,15 @@
       <%= label_tag(:"to_year#{i}", "#{t('search_results.filter.to_year')}", :class=> 'sr-only repeats') %>
       <%= text_field_tag('to_year[]', @search[:to_year][i], :size => 4, :maxlength => 4, :id => "to_year#{i}",
                :class=> 'form-control repeats', :placeholder => t('search_results.filter.to')) %>
+    <%# LIBASPACE-341: Commenting out the "+" button for adding additional
+         search criteria, which is not working as of ArchivesSpace v3.1.1.
+         To restore this functionality, this entire template should be replaced
+         the latest ArchivesSpace version from
+         "public/app/views/shared/_search.html.erb" (preserving UMD
+         customizations), but doing so causes problem with the form layout due
+         to other UMD customizations of the application.
     <span class="plusminus"></span>
+    %>
 
     </div>
   </div>


### PR DESCRIPTION
Commented out the "+" button in the search form that enables additional search criteria to be added. This functionality is not working as of ArchivesSpace v3.1.1, as this UMD-customized template file has not been updated to the latest version of the template
(see "public/app/views/shared/_search.html.erb").

Updating to the stock ArchivesSpace template (and modifying to support the UMD customizations to the template) will enable the search criteria functionality. However, other UMD customizations of the application cause form field layout issues. We are not prepared at this time to undertake fixing these layout issues, so simply removing the functionality is a stop-gap measure.

https://umd-dit.atlassian.net/browse/LIBASPACE-341