### PR TITLE
LIBASPACE-348. Added additional web analytics trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,28 @@
 
 ArchivesSpace plugin for UMD Libraries theme elements
 
+## Web Analytics
+
+Web analytics trackers have been integrated into the page application layout.
+
+Each tracker is activated by specifying the appropriate paramters in the
+ArchivesSpace "AppConfig" object, for retrieval in the ERB templates.
+
+The parameters are optional, in that if they are not provided the
+corresponding tracker will not be added to the layout.
+
+### Google Analytics
+
+* `AppConfig[:public_google_analytics_code]` - The Google Analytics tracking code
+
+### Plausible.io Analytics
+
+* `AppConfig[:plausible_io_analytics_data_domain]` - The Plausible.io
+  "data-domain" value.
+
 ## Environment Banner
 
-Per the SSDR policy specified in https://confluence.umd.edu/display/LIB/Create+Environment+Banners
+Per the SSDR policy specified in <https://confluence.umd.edu/display/LIB/Create+Environment+Banners>
 an environment banner should be shown on all non-production systems.
 
 The display of the environment banner is handled by the

--- a/README.md
+++ b/README.md
@@ -12,18 +12,23 @@ ArchivesSpace "AppConfig" object, for retrieval in the ERB templates.
 The parameters are optional, in that if they are not provided the
 corresponding tracker will not be added to the layout.
 
+### Fathom Analytics
+
+* `AppConfig[:fathom_analytics_data_site]` - The Fathom "data-site" value
+
 ### Google Analytics
 
 * `AppConfig[:public_google_analytics_code]` - The Google Analytics tracking code
+
+### Matomo Analytics
+
+* `AppConfig[:matomo_analytics_url]` - The Matomo URL for the site
+* `AppConfig[:matomo_analytics_site_id]` - The Matomo site id
 
 ### Plausible.io Analytics
 
 * `AppConfig[:plausible_io_analytics_data_domain]` - The Plausible.io
   "data-domain" value.
-
-### Fathom Analytics
-
-* `AppConfig[:fathom_analytics_data_site]` - The Fathom "data-site" value
 
 ## Environment Banner
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ corresponding tracker will not be added to the layout.
 * `AppConfig[:plausible_io_analytics_data_domain]` - The Plausible.io
   "data-domain" value.
 
+### Fathom Analytics
+
+* `AppConfig[:fathom_analytics_data_site]` - The Fathom "data-site" value
+
 ## Environment Banner
 
 Per the SSDR policy specified in <https://confluence.umd.edu/display/LIB/Create+Environment+Banners>

--- a/public/views/layouts/application.html.erb
+++ b/public/views/layouts/application.html.erb
@@ -50,6 +50,26 @@
     <script src="https://cdn.usefathom.com/script.js" data-site="<%= fathom_analytics_data_site %>" defer></script>
   <% end %>
 
+  <% matomo_analytics_url = AppConfig[:matomo_analytics_url] if AppConfig.has_key?(:matomo_analytics_url) %>
+  <% matomo_analytics_site_id = AppConfig[:matomo_analytics_site_id] if AppConfig.has_key?(:matomo_analytics_site_id) %>
+  <% unless (matomo_analytics_url.nil? || matomo_analytics_url.empty? ||  matomo_analytics_site_id.nil? || matomo_analytics_site_id.empty?) %>
+    <!-- Matomo Analytics -->
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="<%= matomo_analytics_url %>";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '<%= matomo_analytics_site_id %>']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src='//cdn.matomo.cloud/umd.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+  <% end %>
+
+
 </head>
 
 <body class="site">

--- a/public/views/layouts/application.html.erb
+++ b/public/views/layouts/application.html.erb
@@ -43,6 +43,13 @@
     <!-- Plausible.io Analytics -->
     <script defer data-domain="<%= plausible_io_analytics_data_domain %>" src="https://plausible.io/js/script.js"></script>
   <% end %>
+
+  <% fathom_analytics_data_site = AppConfig[:fathom_analytics_data_site] if AppConfig.has_key?(:fathom_analytics_data_site) %>
+  <% unless (fathom_analytics_data_site.nil? || fathom_analytics_data_site.empty?) %>
+    <!-- Fathom Analytics -->
+    <script src="https://cdn.usefathom.com/script.js" data-site="<%= fathom_analytics_data_site %>" defer></script>
+  <% end %>
+
 </head>
 
 <body class="site">

--- a/public/views/layouts/application.html.erb
+++ b/public/views/layouts/application.html.erb
@@ -37,6 +37,12 @@
 	<script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 	<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
+
+  <% plausible_io_analytics_data_domain = AppConfig[:plausible_io_analytics_data_domain] if AppConfig.has_key?(:plausible_io_analytics_data_domain) %>
+  <% unless (plausible_io_analytics_data_domain.nil? || plausible_io_analytics_data_domain.empty?) %>
+    <!-- Plausible.io Analytics -->
+    <script defer data-domain="<%= plausible_io_analytics_data_domain %>" src="https://plausible.io/js/script.js"></script>
+  <% end %>
 </head>
 
 <body class="site">


### PR DESCRIPTION
Added the following web analytics trackers:

* Fathom
* Matomo
* Plausible.io

This was done was part of an evaluation of which analytics tracker we might wish to use in the future.

https://umd-dit.atlassian.net/browse/LIBASPACE-348