### PR TITLE
LIBASPACE-350. Removed "Fathom" and "Plausible.io" web trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,14 @@ ArchivesSpace plugin for UMD Libraries theme elements
 
 ## Web Analytics
 
-Web analytics trackers have been integrated into the page application layout.
+The following Web analytics trackers have been integrated into the
+default page layout.
 
-Each tracker is activated by specifying the appropriate paramters in the
+Each tracker is activated by specifying the appropriate parameters in the
 ArchivesSpace "AppConfig" object, for retrieval in the ERB templates.
 
 The parameters are optional, in that if they are not provided the
 corresponding tracker will not be added to the layout.
-
-### Fathom Analytics
-
-* `AppConfig[:fathom_analytics_data_site]` - The Fathom "data-site" value
 
 ### Google Analytics
 
@@ -24,11 +21,6 @@ corresponding tracker will not be added to the layout.
 
 * `AppConfig[:matomo_analytics_url]` - The Matomo URL for the site
 * `AppConfig[:matomo_analytics_site_id]` - The Matomo site id
-
-### Plausible.io Analytics
-
-* `AppConfig[:plausible_io_analytics_data_domain]` - The Plausible.io
-  "data-domain" value.
 
 ## Environment Banner
 

--- a/public/views/layouts/application.html.erb
+++ b/public/views/layouts/application.html.erb
@@ -38,18 +38,6 @@
 	<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
 
-  <% plausible_io_analytics_data_domain = AppConfig[:plausible_io_analytics_data_domain] if AppConfig.has_key?(:plausible_io_analytics_data_domain) %>
-  <% unless (plausible_io_analytics_data_domain.nil? || plausible_io_analytics_data_domain.empty?) %>
-    <!-- Plausible.io Analytics -->
-    <script defer data-domain="<%= plausible_io_analytics_data_domain %>" src="https://plausible.io/js/script.js"></script>
-  <% end %>
-
-  <% fathom_analytics_data_site = AppConfig[:fathom_analytics_data_site] if AppConfig.has_key?(:fathom_analytics_data_site) %>
-  <% unless (fathom_analytics_data_site.nil? || fathom_analytics_data_site.empty?) %>
-    <!-- Fathom Analytics -->
-    <script src="https://cdn.usefathom.com/script.js" data-site="<%= fathom_analytics_data_site %>" defer></script>
-  <% end %>
-
   <% matomo_analytics_url = AppConfig[:matomo_analytics_url] if AppConfig.has_key?(:matomo_analytics_url) %>
   <% matomo_analytics_site_id = AppConfig[:matomo_analytics_site_id] if AppConfig.has_key?(:matomo_analytics_site_id) %>
   <% unless (matomo_analytics_url.nil? || matomo_analytics_url.empty? ||  matomo_analytics_site_id.nil? || matomo_analytics_site_id.empty?) %>
@@ -68,7 +56,6 @@
       })();
     </script>
   <% end %>
-
 
 </head>
 


### PR DESCRIPTION
Removed the "Fathom" and "Plausible.io" web trackers, which were added for testing, from the default page layout.

Updated the README.md

https://umd-dit.atlassian.net/browse/LIBASPACE-350