### PR TITLE
LIBASPACE-352. Removed Google Analytics tracker code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,12 @@ ArchivesSpace plugin for UMD Libraries theme elements
 
 ## Web Analytics
 
-The following Web analytics trackers have been integrated into the
-default page layout.
+The Matomo Web analytics tracker has been integrated into the default page
+layout.
 
-Each tracker is activated by specifying the appropriate parameters in the
+The tracker is activated by specifying the following parameters in the
 ArchivesSpace "AppConfig" object, for retrieval in the ERB templates.
-
-The parameters are optional, in that if they are not provided the
-corresponding tracker will not be added to the layout.
-
-### Google Analytics
-
-* `AppConfig[:public_google_analytics_code]` - The Google Analytics tracking code
-
-### Matomo Analytics
+If they are not provided the tracker will not be added to the layout.
 
 * `AppConfig[:matomo_analytics_url]` - The Matomo URL for the site
 * `AppConfig[:matomo_analytics_site_id]` - The Matomo site id

--- a/public/views/layouts/application.html.erb
+++ b/public/views/layouts/application.html.erb
@@ -93,17 +93,5 @@
   <!-- UMD Wrapper -->
   <script src="https://umd-header.umd.edu/build/bundle.js?search=0&amp;search_domain=&amp;events=0&amp;news=0&amp;schools=0&amp;admissions=0&amp;support=1&amp;support_url=https%253A%252F%252Fgiving.umd.edu%252Fgiving%252FshowSchool.php%253Fname%253Dlibraries&amp;wrapper=1160&amp;sticky=0"></script>
 
-  <% google_analytics_code = AppConfig[:public_google_analytics_code] if AppConfig.has_key?(:public_google_analytics_code) %>
-  <% unless (google_analytics_code.nil? || google_analytics_code.empty?) %>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= google_analytics_code %>"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', '<%= google_analytics_code %>');
-    </script>
-  <% end %>
-
 </body>
 </html>


### PR DESCRIPTION
Removed code for including the Google Analytics tracker, and updated the README.md file.

This makes Matomo the only supported web analytics tracker.

https://umd-dit.atlassian.net/browse/LIBASPACE-352