### PR TITLE
LIBASPACE-377. Updated link text and URL at stakeholder request

### DIFF
--- a/public/views/welcome/show.html.erb
+++ b/public/views/welcome/show.html.erb
@@ -43,7 +43,7 @@
           <p>Special Collections are non-circulating and can be accessed in-person in the designated <a href="https://www.lib.umd.edu/visit/special">reading room</a>. If you cannot visit in-person, we provide <a href="https://www.lib.umd.edu/find/request-digital/special-collections">duplication services</a> for most Special Collections materials.</p>
 
           <p>To submit a request for onsite use or duplication:</p>
-          
+
           <ul>
               <li>Select <b>Request Box</b> at the top of the record.</li>
               <li>Review the box contents and select <b>Request Box</b> again.</li>
@@ -52,7 +52,7 @@
               <li>To request duplication, choose <b>Request Copy</b> and complete the duplication order form.</li>
               <li>Select <b>Submit Information</b> to complete your request.</li>
           </ul>
-          <p>Review our <a href="https://lib.guides.umd.edu/specialcollectionsrequesting">Requesting Special Collections Materials at UMD</a> guide.</p>
+          <p>Review our <a href="https://lib.guides.umd.edu/accessspecialcollections">Accessing Special Collections Materials at UMD</a> guide.</p>
         </div>
 		</div>
 	</div>


### PR DESCRIPTION
Replaced "Requesting Special Collections Materials at UMD" and link https://lib.guides.umd.edu/specialcollectionsrequesting, with "Accessing Special Collections Materials at UMD" and "https://lib.guides.umd.edu/accessspecialcollections" at the request of Cate Mayfield:

> I noticed that the link at the bottom right of the Archival
> Collections Database homepage <https://archives.lib.umd.edu/> is not
> working. On that landing page, it's the linked text below that you'll
> see is leading to an error message:
>
>    Review our Requesting Special Collections Materials at UMD
>    <https://lib.guides.umd.edu/specialcollectionsrequesting> guide.
>    Outdated link: https://lib.guides.umd.edu/specialcollectionsrequesting
>
> Our Research Experience lead updated the guide and related link but we
> are not able to modify the Archival Collections Database homepage
> text/links ourselves. Can you help us to change the text and link to
> this below?:
>
>    Review our Accessing Special Collections Materials at UMD guide.
>    New link: https://lib.guides.umd.edu/accessspecialcollections

https://umd-dit.atlassian.net/browse/LIBASPACE-377